### PR TITLE
fix: replaces getMaxIntrinsic by getDryLayout

### DIFF
--- a/flutter/example/pubspec.yaml
+++ b/flutter/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: yoga_engine_example
 description: Demonstrates how to use the yoga_engine plugin.
+version: 1.0.0+0
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.

--- a/flutter/lib/src/utils/methods.dart
+++ b/flutter/lib/src/utils/methods.dart
@@ -18,6 +18,7 @@ import 'dart:ffi';
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/rendering.dart';
 import 'package:yoga_engine/src/ffi/mapper.dart';
 
 import '../../yoga_engine.dart';
@@ -56,15 +57,19 @@ YGSize measureFunc(
           : height;
 
   final renderObject = helper.getRenderBoxFromNode(node);
+  final constraints = BoxConstraints.loose(
+    Size(constrainedWidth, constrainedHeight),
+  );
+  final renderObjectSize = renderObject?.getDryLayout(constraints);
 
   final sanitizedWidth = _sanitizeMeasurement(
     constrainedWidth,
-    renderObject?.getMaxIntrinsicWidth(constrainedWidth) ?? 0,
+    renderObjectSize?.width ?? 0,
     widthMeasureMode,
   );
   final sanitizedHeight = _sanitizeMeasurement(
     constrainedHeight,
-    renderObject?.getMaxIntrinsicHeight(constrainedHeight) ?? 0,
+    renderObjectSize?.height ?? 0,
     heightMeasureMode,
   );
 


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

The `measureFunc` returned the smallest size the component wanted to have, now it returns the desired size of the component given its constraints. This change fixes cases where widgets that use all available space, were occupying their children's space only.