### PR TITLE
fix: RenderBox cast changed to RenderObject

### DIFF
--- a/flutter/lib/src/layout/yoga_render.dart
+++ b/flutter/lib/src/layout/yoga_render.dart
@@ -168,14 +168,14 @@ class RenderYoga extends RenderBox
     }
   }
 
-  _iterateOverYogaNodes(RenderBox child, NodeProperties nodePropertiesLeaf) {
+  _iterateOverYogaNodes(RenderObject child, NodeProperties nodePropertiesLeaf) {
     int index = 0;
     child.visitChildren((innerChild) {
       if (innerChild is RenderYoga) {
         nodePropertiesLeaf.insertChildAt(innerChild.nodeProperties, index);
         _attachNodesFromWidgetsHierarchy(innerChild);
       } else {
-        _iterateOverYogaNodes(innerChild as RenderBox, nodePropertiesLeaf);
+        _iterateOverYogaNodes(innerChild, nodePropertiesLeaf);
       }
       index++;
     });


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

Fixed unnecessary cast to RenderBox. There is some cases when this will fail.