### PR TITLE
fix: flutter layout iteration

### DIFF
--- a/flutter/README.md
+++ b/flutter/README.md
@@ -65,4 +65,3 @@ YogaLayout(
 - `YogaLayout` widgets can only have children of `YogaLayout` or `YogaNode` types.
 - `YogaNode` widgets can have any type of child, except themselves.
 - `YogaNode` widgets cannot be placed outside `YogaLayout`.
-- When a `YogaLayout` is placed inside a `YogaNode`, this must have the property `isLeaf = false`.

--- a/flutter/example/README.md
+++ b/flutter/example/README.md
@@ -25,8 +25,6 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     NodeProperties child1 = NodeProperties();
-    child1.setWidth(50);
-    child1.setHeight(50);
 
     NodeProperties child2 = NodeProperties();
 
@@ -61,7 +59,6 @@ class _MyAppState extends State<MyApp> {
                 ),
               ),
               YogaNode(
-                isLeaf: false,
                 nodeProperties: child2,
                 child: ColoredBox(
                   color: Colors.pink,

--- a/flutter/example/lib/main.dart
+++ b/flutter/example/lib/main.dart
@@ -36,8 +36,6 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     NodeProperties child1 = NodeProperties();
-    child1.setWidth(50);
-    child1.setHeight(50);
 
     NodeProperties child2 = NodeProperties();
 
@@ -72,7 +70,6 @@ class _MyAppState extends State<MyApp> {
                 ),
               ),
               YogaNode(
-                isLeaf: false,
                 nodeProperties: child2,
                 child: ColoredBox(
                   color: Colors.pink,

--- a/flutter/lib/src/layout/yoga_render.dart
+++ b/flutter/lib/src/layout/yoga_render.dart
@@ -168,14 +168,14 @@ class RenderYoga extends RenderBox
     }
   }
 
-  _iterateOverYogaNodes(RenderBox child, NodeProperties nodePropertiesLeaf) {
+  _iterateOverYogaNodes(RenderObject child, NodeProperties nodePropertiesLeaf) {
     int index = 0;
     child.visitChildren((innerChild) {
       if (innerChild is RenderYoga) {
         nodePropertiesLeaf.insertChildAt(innerChild.nodeProperties, index);
         _attachNodesFromWidgetsHierarchy(innerChild);
       } else {
-        _iterateOverYogaNodes(innerChild as RenderBox, nodePropertiesLeaf);
+        _iterateOverYogaNodes(innerChild, nodePropertiesLeaf);
       }
       index++;
     });

--- a/flutter/lib/src/layout/yoga_render.dart
+++ b/flutter/lib/src/layout/yoga_render.dart
@@ -26,29 +26,26 @@ import 'package:yoga_engine/src/utils/node_helper.dart';
 import '../yoga_initializer.dart';
 
 class YogaParentData extends ContainerBoxParentData<RenderBox> {
-  bool? isLeaf;
   NodeProperties? nodeProperties;
 
   @override
   String toString() => '${super.toString()}; '
-      'nodeProperties=$nodeProperties; '
-      'isLeaf=$isLeaf';
+      'nodeProperties=$nodeProperties';
 }
 
 /// Class responsible to measure any flutter widget by the NodeProperties.
 /// This can only be placed inside a YogaLayout widget and cannot have another
 /// YogaNode as a direct child.
-/// Pass false to isLeaf property when this class is not placed at the end of
-/// the widget tree.
+/// Use this class to wrap around any flutter widget. The yoga will be able
+/// to calculate the layout size and the children offsets,
+/// given this wrapped widget's size.
 class YogaNode extends ParentDataWidget<YogaParentData> {
   const YogaNode({
     Key? key,
-    this.isLeaf = true,
     required this.nodeProperties,
     required Widget child,
   }) : super(key: key, child: child);
 
-  final bool isLeaf;
   final NodeProperties nodeProperties;
 
   @override
@@ -56,11 +53,6 @@ class YogaNode extends ParentDataWidget<YogaParentData> {
     assert(renderObject.parentData is YogaParentData);
     final parentData = renderObject.parentData! as YogaParentData;
     bool needsLayout = false;
-
-    if (parentData.isLeaf != isLeaf) {
-      parentData.isLeaf = isLeaf;
-      needsLayout = true;
-    }
 
     if (parentData.nodeProperties != nodeProperties) {
       parentData.nodeProperties = nodeProperties;
@@ -79,7 +71,6 @@ class YogaNode extends ParentDataWidget<YogaParentData> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(StringProperty('isLeaf', isLeaf.toString()));
     properties.add(StringProperty('nodeProperties', nodeProperties.toString()));
   }
 }
@@ -115,22 +106,33 @@ class RenderYoga extends RenderBox
     }
   }
 
-  bool _isLeaf(YogaParentData yogaParentData) {
-    return yogaParentData.isLeaf ?? false;
-  }
-
   NodeProperties _getNodeProperties(YogaParentData yogaParentData) {
     return yogaParentData.nodeProperties!;
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    if (!nodeProperties.isCalculated()) {
+      _attachNodesFromWidgetsHierarchy(this);
+      nodeProperties.calculateLayout(YGUndefined, YGUndefined);
+    }
+    return Size(
+      nodeProperties.getLayoutWidth(),
+      nodeProperties.getLayoutHeight(),
+    );
   }
 
   @override
   void performLayout() {
     if (!nodeProperties.isCalculated()) {
       _attachNodesFromWidgetsHierarchy(this);
-      nodeProperties.calculateLayout(
-        constraints.maxWidth.floorToDouble(),
-        constraints.maxHeight.floorToDouble(),
-      );
+      final maxWidth = constraints.maxWidth.isInfinite
+          ? YGUndefined
+          : constraints.maxWidth.floorToDouble();
+      final maxHeight = constraints.maxHeight.isInfinite
+          ? YGUndefined
+          : constraints.maxHeight.floorToDouble();
+      nodeProperties.calculateLayout(maxWidth, maxHeight);
     }
     _applyLayoutToWidgetsHierarchy(getChildrenAsList());
 
@@ -156,29 +158,16 @@ class RenderYoga extends RenderBox
           throw FlutterError('To use YogaLayout, you must declare every child '
               'inside a YogaNode or YogaLayout component');
         }());
-        final yogaNodeLeaf = _getNodeProperties(yogaParentData);
-        renderYoga.nodeProperties.insertChildAt(yogaNodeLeaf, i);
-        if (_isLeaf(yogaParentData)) {
-          _helper.setRenderBoxToNode(child, yogaNodeLeaf.node);
-          yogaNodeLeaf.setMeasureFunc();
-        } else {
-          _iterateOverYogaNodes(child, yogaNodeLeaf);
-        }
+        final childYogaNode = _getNodeProperties(yogaParentData);
+        renderYoga.nodeProperties.insertChildAt(childYogaNode, i);
+        _setMeasureFunction(child, childYogaNode);
       }
     }
   }
 
-  _iterateOverYogaNodes(RenderObject child, NodeProperties nodePropertiesLeaf) {
-    int index = 0;
-    child.visitChildren((innerChild) {
-      if (innerChild is RenderYoga) {
-        nodePropertiesLeaf.insertChildAt(innerChild.nodeProperties, index);
-        _attachNodesFromWidgetsHierarchy(innerChild);
-      } else {
-        _iterateOverYogaNodes(innerChild, nodePropertiesLeaf);
-      }
-      index++;
-    });
+  void _setMeasureFunction(RenderBox child, NodeProperties childYogaNode) {
+    _helper.setRenderBoxToNode(child, childYogaNode.node);
+    childYogaNode.setMeasureFunc();
   }
 
   void _applyLayoutToWidgetsHierarchy(List<RenderBox> children) {
@@ -196,21 +185,12 @@ class RenderYoga extends RenderBox
         _helper.getTop(node),
       );
       late BoxConstraints childConstraints;
-      if (yogaParentData.isLeaf != null && yogaParentData.isLeaf!) {
-        childConstraints = BoxConstraints.tight(
-          Size(
-            _helper.getLayoutWidth(node),
-            _helper.getLayoutHeight(node),
-          ),
-        );
-      } else {
-        childConstraints = BoxConstraints.loose(
-          Size(
-            _helper.getLayoutWidth(node),
-            _helper.getLayoutHeight(node),
-          ),
-        );
-      }
+      childConstraints = BoxConstraints.tight(
+        Size(
+          _helper.getLayoutWidth(node),
+          _helper.getLayoutHeight(node),
+        ),
+      );
       child.layout(childConstraints, parentUsesSize: true);
       _helper.removeNodeReference(node);
     }


### PR DESCRIPTION
This PR changes the layout render logics. Instead of iterating over the `YogaNode` leaves, it is treated every `YogaNode` as a leaf. Other changes:
- `isLeaf` property removed, its no longer needed;
- Main example changed;
- API doc updated;
- Unconstrained layouts handle.