### PR TITLE
fix: TextField rendering

### DIFF
--- a/flutter/CHANGELOG.md
+++ b/flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Fix TextField rendering
+
 ## 0.0.2
 
 * Android points to local .so files instead of building them from CMakeLists.txt

--- a/flutter/lib/src/utils/methods.dart
+++ b/flutter/lib/src/utils/methods.dart
@@ -60,16 +60,25 @@ YGSize measureFunc(
   final constraints = BoxConstraints.loose(
     Size(constrainedWidth, constrainedHeight),
   );
-  final renderObjectSize = renderObject?.getDryLayout(constraints);
+  double objectWidth;
+  double objectHeight;
+  if (renderObject is RenderMouseRegion) {
+    objectWidth = renderObject.getMaxIntrinsicWidth(constrainedWidth);
+    objectHeight = renderObject.getMaxIntrinsicHeight(constrainedHeight);
+  } else {
+    final renderObjectSize = renderObject?.getDryLayout(constraints);
+    objectWidth = renderObjectSize?.width ?? 0;
+    objectHeight = renderObjectSize?.height ?? 0;
+  }
 
   final sanitizedWidth = _sanitizeMeasurement(
     constrainedWidth,
-    renderObjectSize?.width ?? 0,
+    objectWidth,
     widthMeasureMode,
   );
   final sanitizedHeight = _sanitizeMeasurement(
     constrainedHeight,
-    renderObjectSize?.height ?? 0,
+    objectHeight,
     heightMeasureMode,
   );
 

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: yoga_engine
 description: A plugin that uses yoga to implements flexbox layout in Flutter.
-version: 0.0.2
+version: 0.0.3
 homepage: https://github.com/ZupIT/yoga/tree/master/flutter
 
 environment:
@@ -10,15 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  get_it: ^7.1.3
+  get_it: ^7.2.0
 
 dev_dependencies:
-  build_runner: ^2.0.4
+  build_runner: ^2.0.6
   ffigen: ^3.0.0
   flutter_test:
     sdk: flutter
   lints: ^1.0.1
-  mockito: ^5.0.10
+  mockito: ^5.0.12
 
 ffigen:
   name: Yoga


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>

## Description
There are some `RenderObject`s in Flutter that don't implement the `getDryLayout` method, such as the `TextField` widget, so it wasn't rendered. This PR adds a handle to the `RenderMouseRegion`, which is the `RenderObject` used by the `TextField` widget.

## Other considerations
This is not a scalable solution, it may be that other widgets have the same behavior and therefore new fixes will have to be done. However, as the Beagle (the only `yoga_engine` user) has only `TextField` with this behavior, for now this is an acceptable solution.