### PR TITLE
feat: Recalculate layout

### DIFF
--- a/flutter/lib/src/layout/node_properties.dart
+++ b/flutter/lib/src/layout/node_properties.dart
@@ -371,6 +371,16 @@ class NodeProperties {
 
   bool isCalculated() {
     return !_mapper.yGNodeLayoutGetWidth(_node).isNaN &&
-        !_mapper.yGNodeLayoutGetHeight(_node).isNaN;
+        !_mapper.yGNodeLayoutGetHeight(_node).isNaN &&
+        !_mapper.yGNodeIsDirty(_node)
+    ;
+  }
+
+  void removeAllChildren() {
+    _mapper.yGNodeRemoveAllChildren(node);
+  }
+
+  void dirtyAllDescendants() {
+    _mapper.yGNodeMarkDirtyAndPropagateToDescendants(_node);
   }
 }

--- a/flutter/lib/src/layout/node_properties.dart
+++ b/flutter/lib/src/layout/node_properties.dart
@@ -383,4 +383,8 @@ class NodeProperties {
   void dirtyAllDescendants() {
     _mapper.yGNodeMarkDirtyAndPropagateToDescendants(_node);
   }
+
+  bool isDirty() {
+    return _mapper.yGNodeIsDirty(_node);
+  }
 }

--- a/flutter/lib/src/layout/yoga_render.dart
+++ b/flutter/lib/src/layout/yoga_render.dart
@@ -91,7 +91,7 @@ class MeasureSizeRenderObject extends RenderProxyBox {
     Size newSize = child?.size ?? Size.zero;
     if (newSize == oldSize) return;
 
-    debugPrint("Size changed ${child} oldSize: ${oldSize.toString()} newSize: ${newSize.toString()}");
+    debugPrint("Size changed $child oldSize: ${oldSize.toString()} newSize: ${newSize.toString()}");
     oldSize = newSize;
 
     WidgetsBinding.instance?.addPostFrameCallback((_) {
@@ -101,16 +101,9 @@ class MeasureSizeRenderObject extends RenderProxyBox {
 
   void _recalculateLayout(AbstractNode? targetParent) {
     if (targetParent is RenderYoga) {
-      // if (targetParent.parent is MeasureSizeRenderObject &&
-      //     (targetParent.parent as MeasureSizeRenderObject).parent is RenderYoga) {
-      //   final superParent = (targetParent.parent as MeasureSizeRenderObject).parent as RenderYoga;
-      //   superParent.nodeProperties.dirtyAllDescendants();
-      //   superParent.nodeProperties.removeAllChildren();
-      // } else {
       //FIXME Trigger rebuild if we have more than one container ancestor. example Container(container( image) ) )
         targetParent.nodeProperties.dirtyAllDescendants();
         targetParent.nodeProperties.removeAllChildren();
-      // }
     }
   }
 }
@@ -167,9 +160,6 @@ class RenderYoga extends RenderBox
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     if (!nodeProperties.isCalculated()) {
-      if(nodeProperties.isDirty() && nodeProperties.getChildCount() > 0) {
-        nodeProperties.removeAllChildren();
-      }
       _attachNodesFromWidgetsHierarchy(this);
       nodeProperties.calculateLayout(YGUndefined, YGUndefined);
     }
@@ -182,9 +172,6 @@ class RenderYoga extends RenderBox
   @override
   void performLayout() {
     if (!nodeProperties.isCalculated()) {
-      if(nodeProperties.isDirty() && nodeProperties.getChildCount() > 0) {
-        nodeProperties.removeAllChildren();
-      }
       _attachNodesFromWidgetsHierarchy(this);
       final maxWidth = constraints.maxWidth.isInfinite
           ? YGUndefined
@@ -206,8 +193,8 @@ class RenderYoga extends RenderBox
     final children = renderYoga.getChildrenAsList();
     for (var i = 0; i < children.length; i++) {
       var child = children[i];
-      if (child is MeasureSizeRenderObject && child.child is MeasureSizeRenderObject && (child.child as MeasureSizeRenderObject).child is RenderYoga) {
-        child = (child.child as MeasureSizeRenderObject).child!;
+      if (child is MeasureSizeRenderObject && child.child is RenderYoga) {
+        child = child.child!;
       }
 
       if (child is RenderYoga) {
@@ -239,9 +226,9 @@ class RenderYoga extends RenderBox
       var child = children[i];
       RenderBox? originalChild = null;
       final yogaParentData = child.parentData as YogaParentData;
-      if (child is MeasureSizeRenderObject && child.child is MeasureSizeRenderObject && (child.child as MeasureSizeRenderObject).child is RenderYoga) {
+      if (child is MeasureSizeRenderObject && child.child is RenderYoga) {
         originalChild = child;
-        child = (child.child as MeasureSizeRenderObject).child!;
+        child = child.child!;
       }
 
       late Pointer<YGNode> node;
@@ -263,7 +250,6 @@ class RenderYoga extends RenderBox
       );
 
       if(originalChild != null) {
-        child.layout(childConstraints, parentUsesSize: true);
         originalChild.layout(childConstraints, parentUsesSize: true);
       } else {
         child.layout(childConstraints, parentUsesSize: true);
@@ -293,7 +279,6 @@ class YogaLayout extends MultiChildRenderObjectWidget {
     List<Widget> children = const <Widget>[],
   }) : super(key: key,
       children: children,
-      // children: children.map((child) => _observeLayoutChanges(child)).toList()
   );
 
   final NodeProperties nodeProperties;

--- a/flutter/lib/src/layout/yoga_render.dart
+++ b/flutter/lib/src/layout/yoga_render.dart
@@ -206,8 +206,8 @@ class RenderYoga extends RenderBox
     final children = renderYoga.getChildrenAsList();
     for (var i = 0; i < children.length; i++) {
       var child = children[i];
-      if (child is MeasureSizeRenderObject && child.child is RenderYoga) {
-        child = (child).child!;
+      if (child is MeasureSizeRenderObject && child.child is MeasureSizeRenderObject && (child.child as MeasureSizeRenderObject).child is RenderYoga) {
+        child = (child.child as MeasureSizeRenderObject).child!;
       }
 
       if (child is RenderYoga) {
@@ -239,9 +239,9 @@ class RenderYoga extends RenderBox
       var child = children[i];
       RenderBox? originalChild = null;
       final yogaParentData = child.parentData as YogaParentData;
-      if (child is MeasureSizeRenderObject && child.child is RenderYoga) {
+      if (child is MeasureSizeRenderObject && child.child is MeasureSizeRenderObject && (child.child as MeasureSizeRenderObject).child is RenderYoga) {
         originalChild = child;
-        child = (child).child!;
+        child = (child.child as MeasureSizeRenderObject).child!;
       }
 
       late Pointer<YGNode> node;

--- a/flutter/lib/yoga_engine.dart
+++ b/flutter/lib/yoga_engine.dart
@@ -17,5 +17,5 @@
 export 'package:yoga_engine/src/yoga_initializer.dart' show Yoga;
 export 'package:yoga_engine/src/layout/node_properties.dart';
 export 'package:yoga_engine/src/layout/yoga_render.dart'
-    show YogaNode, YogaLayout, MeasureSize;
+    show YogaNode, YogaLayout;
 export 'package:yoga_engine/src/ffi/types.dart';

--- a/flutter/lib/yoga_engine.dart
+++ b/flutter/lib/yoga_engine.dart
@@ -17,5 +17,5 @@
 export 'package:yoga_engine/src/yoga_initializer.dart' show Yoga;
 export 'package:yoga_engine/src/layout/node_properties.dart';
 export 'package:yoga_engine/src/layout/yoga_render.dart'
-    show YogaNode, YogaLayout;
+    show YogaNode, YogaLayout, MeasureSize;
 export 'package:yoga_engine/src/ffi/types.dart';


### PR DESCRIPTION
## How yoga works with beagle flutter
Today to use Yoga, we have the classes 
YogaLayout (MultiChildWidgets)-> that is rendered by RenderYoga
YogaNode (single child widgets) -> That wraps the widgets to represent a leaf for the yoga tree.

The process is as following:

1- We need to create a yoga tree with all the widgets flex attributes (_attachNodesFromWidgetsHierarchy)
2- We need to call the nodeProperties.calculateLayout(maxWidth, maxHeight); on the root node.
3- Read the sizes and apply to the widgets with child.layout(childConstraints, parentUsesSize: true); (_applyLayoutToWidgetsHierarchy)
4- Set the size for the root node reading the width/height calculated by yoga. 


## The problem of recalculate layouts
When using a widget with yoga, if the size of the widget changes during the rendering we need to recalculate the yoga width/height . For that the current implementation is marking the nodeProperties as dirty and deleting the nodes to let the performLayout method inside the RenderYoga re-create the yoga tree


Below some screenshots of the current code working with image example without fixed sizes
### Image starting to render starting with size 0
![image](https://user-images.githubusercontent.com/45759570/140559481-6ad6ff31-1dc4-4641-be70-6be61839bc11.png)
### Image finishing to render and its size is calculated 
![image](https://user-images.githubusercontent.com/45759570/140561532-7904a208-da8f-45aa-b9bb-0c002ae70008.png)

## Known issues for this implementation
The error is below
![image](https://user-images.githubusercontent.com/45759570/140564008-34062c67-2cd6-4a40-a6f8-b03669b85cb7.png)

Currently if we have the example as it is on https://github.com/Orangestack-com/beagle-backend-kotlin/tree/feaeture/recalculate-layout it works. But if we wrap the bff code with one more BeagleContainer, for some reason the image is rendering small, need some more investigation to know if the BeagleContainer is not being recalculated, or the image is being calculated with small(older) BoxConstraints and its small because of that.

```


Container(children = listOf(Container(
            children = listOf(
                buildText(title),
                Image(Remote(this.imagePath), mode).setStyle {
                    flex = Flex(
                        alignSelf = AlignSelf.CENTER
                    )
//                size = Size(
//                    width = UnitValue.real(150),
//                    height = UnitValue.real(130)
//                )
                }
            )
        )))
```


## How to Configure for local development
Download yoga repository inside the beagle flutter's repository root folder for local development
Change beagle's pubspec .yaml to point to the local development yoga as following
yoga_engine:
    path: ../yoga/flutter

[Beagle Flutter]
https://github.com/Orangestack-com/beagle-flutter

Yoga
https://github.com/ZupIT/yoga/tree/feature/recalculate-layout
[BFF]
https://github.com/Orangestack-com/beagle-backend-kotlin/tree/feaeture/recalculate-layout

* Download yoga repository inside the beagle flutter's repository root folder for local development
* Change beagle's pubspec .yaml to point to the local development yoga as following
yoga_engine:
    path: ../yoga/flutter

[Beagle Flutter]
https://github.com/Orangestack-com/beagle-flutter
Yoga
https://github.com/ZupIT/yoga/tree/feature/recalculate-layout
[BFF]
https://github.com/Orangestack-com/beagle-backend-kotlin/tree/feaeture/recalculate-layout